### PR TITLE
Require landlab 2.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: wntrblm/nox@2022.11.21
         with:
           python-versions: "3.9, 3.10, 3.11"

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ bmi-geotiff
 bmi-topography
 imageio[ffmpeg]>=2.19.1
 jupyter
-landlab>=2.4.1
+landlab>=2.6
 matplotlib
-numpy<1.25.0
+numpy
 tqdm


### PR DESCRIPTION
This pull request requires the latest version of *Landlab* (v2.6) and drops the version requirement for *numpy* (which was needed for the older version of *Landlab*). I've also bumped *actions/checkout* from v2 to v3, which obviates the need for #2.